### PR TITLE
Add writeUTF method to ByteStreamWriter

### DIFF
--- a/src/main/java/me/hugmanrique/jacobin/base/BaseByteStreamReader.java
+++ b/src/main/java/me/hugmanrique/jacobin/base/BaseByteStreamReader.java
@@ -5,7 +5,6 @@ import me.hugmanrique.jacobin.reader.ByteStreamReader;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -102,13 +101,5 @@ public abstract class BaseByteStreamReader implements ByteStreamReader {
         offset.incrementAndGet();
 
         return value;
-    }
-
-    @Override
-    public String readUTF(int length) throws IOException {
-        byte[] bytes = new byte[length];
-        read(bytes, 0, length);
-
-        return new String(bytes, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/me/hugmanrique/jacobin/base/BaseByteStreamWriter.java
+++ b/src/main/java/me/hugmanrique/jacobin/base/BaseByteStreamWriter.java
@@ -4,6 +4,7 @@ import me.hugmanrique.jacobin.writer.ByteStreamWriter;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -59,5 +60,13 @@ public abstract class BaseByteStreamWriter implements ByteStreamWriter {
     public void writeByte(int value) throws IOException {
         stream.write(value);
         this.offset.incrementAndGet();
+    }
+
+    @Override
+    public int writeUTF(String value) throws IOException {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        write(bytes);
+
+        return bytes.length;
     }
 }

--- a/src/main/java/me/hugmanrique/jacobin/base/BaseByteStreamWriter.java
+++ b/src/main/java/me/hugmanrique/jacobin/base/BaseByteStreamWriter.java
@@ -61,12 +61,4 @@ public abstract class BaseByteStreamWriter implements ByteStreamWriter {
         stream.write(value);
         this.offset.incrementAndGet();
     }
-
-    @Override
-    public int writeUTF(String value) throws IOException {
-        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
-        write(bytes);
-
-        return bytes.length;
-    }
 }

--- a/src/main/java/me/hugmanrique/jacobin/order/ByteOrderReader.java
+++ b/src/main/java/me/hugmanrique/jacobin/order/ByteOrderReader.java
@@ -94,7 +94,7 @@ public interface ByteOrderReader {
      * depends on the {@link StandardCharsets#UTF_8} charset, and hence may
      * not be equal to {@code length}.
      *
-     * @param length an int specifying the number of bytes to read
+     * @param length the maximum number of bytes to read
      * @return the Unicode string read
      * @throws EOFException if the stream reaches the end before reading all the bytes
      * @throws IOException if an I/O error occurs

--- a/src/main/java/me/hugmanrique/jacobin/order/ByteOrderWriter.java
+++ b/src/main/java/me/hugmanrique/jacobin/order/ByteOrderWriter.java
@@ -1,6 +1,7 @@
 package me.hugmanrique.jacobin.order;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A byte-order dependent byte stream writer interface.
@@ -79,4 +80,16 @@ public interface ByteOrderWriter {
         // TODO Print warning?
         writeInt64(value);
     }
+
+    /**
+     * Writes the UTF-8 {@link String} byte representation of every character
+     * in the string {@code value}. Note that the number of written bytes
+     * depends on the {@link StandardCharsets#UTF_8} charset, and hence may
+     * not be equal to {@code string.length()}.
+     *
+     * @param value the string to be written
+     * @return the number of bytes written
+     * @throws IOException if an I/O error occurs
+     */
+    int writeUTF(String value) throws IOException;
 }

--- a/src/main/java/me/hugmanrique/jacobin/order/ByteOrderWriter.java
+++ b/src/main/java/me/hugmanrique/jacobin/order/ByteOrderWriter.java
@@ -1,5 +1,7 @@
 package me.hugmanrique.jacobin.order;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
@@ -91,5 +93,6 @@ public interface ByteOrderWriter {
      * @return the number of bytes written
      * @throws IOException if an I/O error occurs
      */
+    @CanIgnoreReturnValue
     int writeUTF(String value) throws IOException;
 }

--- a/src/main/java/me/hugmanrique/jacobin/reader/ByteStreamReader.java
+++ b/src/main/java/me/hugmanrique/jacobin/reader/ByteStreamReader.java
@@ -60,8 +60,8 @@ public interface ByteStreamReader extends ByteOrderReader, Closeable {
      * calls on the same stream will return zero.
      *
      * @param buffer the buffer into which the data is read
-     * @param offset an int specifying the offset into the data
-     * @param length an int specifying the number of bytes to read
+     * @param offset the start offset in array {@code buffer} at which the data is written
+     * @param length the maximum number of bytes to read
      * @return the number of bytes read
      * @throws IOException if an I/O error occurs
      * @throws NullPointerException if {@code buffer} is null
@@ -74,8 +74,8 @@ public interface ByteStreamReader extends ByteOrderReader, Closeable {
 
     /**
      * Returns whether this reader supports going back to an already read
-     * byte offset by checking if the underlaying {@link InputStream} supports
-     * marks.
+     * byte offset by checking if the underlying {@link InputStream} supports
+     * the {@code mark} and {@code reset} methods.
      *
      * @see #getOffset()
      * @see InputStream#markSupported()

--- a/src/main/java/me/hugmanrique/jacobin/writer/ByteStreamWriter.java
+++ b/src/main/java/me/hugmanrique/jacobin/writer/ByteStreamWriter.java
@@ -36,8 +36,8 @@ public interface ByteStreamWriter extends ByteOrderWriter, Closeable {
      * Writes {@code length} bytes from the {@code data} array, in order, to the internal stream.
      *
      * @param data the data to write to the stream
-     * @param offset an int specifying the offset in the data
-     * @param length an int specifying the number of bytes to write
+     * @param offset the start offset in the {@code data} array
+     * @param length the number of bytes to write
      * @throws IOException if an I/O error occurs
      * @throws NullPointerException if {@code data} is null
      * @throws IndexOutOfBoundsException if {@code offset} is negative, or {@code length} is negative, or

--- a/src/main/java/me/hugmanrique/jacobin/writer/ByteStreamWriter.java
+++ b/src/main/java/me/hugmanrique/jacobin/writer/ByteStreamWriter.java
@@ -4,6 +4,7 @@ import me.hugmanrique.jacobin.order.ByteOrderWriter;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Provides a way to write data into a stream.
@@ -53,4 +54,12 @@ public interface ByteStreamWriter extends ByteOrderWriter, Closeable {
      * @throws NullPointerException if {@code data} is null
      */
     void write(byte[] data) throws IOException;
+
+    @Override
+    default int writeUTF(String value) throws IOException {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        write(bytes);
+
+        return bytes.length;
+    }
 }

--- a/src/test/java/me/hugmanrique/jacobin/writer/BigEndianByteStreamWriterTest.java
+++ b/src/test/java/me/hugmanrique/jacobin/writer/BigEndianByteStreamWriterTest.java
@@ -1,0 +1,14 @@
+package me.hugmanrique.jacobin.writer;
+
+import java.nio.ByteOrder;
+
+/**
+ * @author Hugo Manrique
+ * @since 22/12/2018
+ */
+public class BigEndianByteStreamWriterTest extends EndiannessByteStreamWriterTest {
+
+    public BigEndianByteStreamWriterTest() {
+        super(ByteOrder.BIG_ENDIAN);
+    }
+}

--- a/src/test/java/me/hugmanrique/jacobin/writer/ByteStreamWriterTest.java
+++ b/src/test/java/me/hugmanrique/jacobin/writer/ByteStreamWriterTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 
@@ -67,5 +68,15 @@ public class ByteStreamWriterTest {
 
         assertEquals(value, reader.readInt64());
         assertEquals("Writer must write 8 bytes", 0, reader.available());
+    }
+
+    protected void assertWriteString(String value) throws Exception {
+        newReader();
+
+        // TODO I believe this test is superfluous
+        int expectedWriteBytes = value.getBytes(StandardCharsets.UTF_8).length;
+
+        assertEquals(value, reader.readUTF(value.length()));
+        assertEquals("Writer must write " + expectedWriteBytes + " bytes", 0, reader.available());
     }
 }

--- a/src/test/java/me/hugmanrique/jacobin/writer/EndiannessByteStreamWriterTest.java
+++ b/src/test/java/me/hugmanrique/jacobin/writer/EndiannessByteStreamWriterTest.java
@@ -1,5 +1,6 @@
 package me.hugmanrique.jacobin.writer;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.nio.ByteOrder;
@@ -12,6 +13,7 @@ import java.nio.ByteOrder;
  * @author Hugo Manrique
  * @since 22/12/2018
  */
+@Ignore
 public class EndiannessByteStreamWriterTest extends ByteStreamWriterTest {
 
     public EndiannessByteStreamWriterTest(ByteOrder byteOrder) {

--- a/src/test/java/me/hugmanrique/jacobin/writer/EndiannessByteStreamWriterTest.java
+++ b/src/test/java/me/hugmanrique/jacobin/writer/EndiannessByteStreamWriterTest.java
@@ -1,0 +1,44 @@
+package me.hugmanrique.jacobin.writer;
+
+import org.junit.Test;
+
+import java.nio.ByteOrder;
+
+/**
+ * The writing test implementation creates a writer and a reader instance.
+ * This means we depend on the reader's implementation being correct, but
+ * their behavior is tested on the {@code reader} package.
+ *
+ * @author Hugo Manrique
+ * @since 22/12/2018
+ */
+public class EndiannessByteStreamWriterTest extends ByteStreamWriterTest {
+
+    public EndiannessByteStreamWriterTest(ByteOrder byteOrder) {
+        super(byteOrder);
+    }
+
+    @Test
+    public void testByteWrite() throws Exception {
+        writer.writeByte(0x12);
+        assertWriteByte(0x12);
+    }
+
+    @Test
+    public void testInt16Write() throws Exception {
+        writer.writeInt16((short) 0x1234);
+        assertWriteInt16((short) 0x1234);
+    }
+
+    @Test
+    public void testInt32Write() throws Exception {
+        writer.writeInt32(0x12345678);
+        assertWriteInt32(0x12345678);
+    }
+
+    @Test
+    public void testInt64Write() throws Exception {
+        writer.writeInt64(0x123456789ABCDEF0L);
+        assertWriteInt64(0x123456789ABCDEF0L);
+    }
+}

--- a/src/test/java/me/hugmanrique/jacobin/writer/LittleEndianByteStreamWriterTest.java
+++ b/src/test/java/me/hugmanrique/jacobin/writer/LittleEndianByteStreamWriterTest.java
@@ -8,38 +8,13 @@ import java.nio.ByteOrder;
  * @author Hugo Manrique
  * @since 03/09/2018
  */
-public class LittleEndianByteStreamWriterTest extends ByteStreamWriterTest {
+public class LittleEndianByteStreamWriterTest extends EndiannessByteStreamWriterTest {
 
     public LittleEndianByteStreamWriterTest() {
         super(ByteOrder.LITTLE_ENDIAN);
     }
 
-    @Test
-    public void testByteWrite() throws Exception {
-        writer.writeByte(0x12);
-        assertWriteByte(0x12);
-    }
-
-    @Test
-    public void testInt16Write() throws Exception {
-        writer.writeInt16((short) 0x1234);
-        assertWriteInt16((short) 0x1234);
-    }
-
-    @Test
-    public void testInt32Write() throws Exception {
-        writer.writeInt32(0x12345678);
-        assertWriteInt32(0x12345678);
-    }
-
-    @Test
-    public void testInt64Write() throws Exception {
-        writer.writeInt64(0x123456789ABCDEF0L);
-        assertWriteInt64(0x123456789ABCDEF0L);
-    }
-
-    // UTF-8 is endianness-independent, so the string writing
-    // test is only executed here.
+    // UTF-8 is endianness-independent, so string writing is only tested once.
     @Test
     public void testStringWrite() throws Exception {
         String testString = "abcdef12345678";

--- a/src/test/java/me/hugmanrique/jacobin/writer/LittleEndianByteStreamWriterTest.java
+++ b/src/test/java/me/hugmanrique/jacobin/writer/LittleEndianByteStreamWriterTest.java
@@ -37,4 +37,14 @@ public class LittleEndianByteStreamWriterTest extends ByteStreamWriterTest {
         writer.writeInt64(0x123456789ABCDEF0L);
         assertWriteInt64(0x123456789ABCDEF0L);
     }
+
+    // UTF-8 is endianness-independent, so the string writing
+    // test is only executed here.
+    @Test
+    public void testStringWrite() throws Exception {
+        String testString = "abcdef12345678";
+
+        writer.writeUTF(testString);
+        assertWriteString(testString);
+    }
 }


### PR DESCRIPTION
This PR adds a `writeUTF` to the ByteStreamWriter and InOutByteStream classes and also clarifies some javadocs.